### PR TITLE
Enable alpha as an aesthetic

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,8 @@ Depends:
     ggplot2 (>= 2.0.0)
 Imports:
     grid,
-    Rcpp
+    Rcpp,
+    scales
 Suggests:
     knitr,
     rmarkdown

--- a/R/geom-text-repel.R
+++ b/R/geom-text-repel.R
@@ -291,14 +291,14 @@ makeContent.textrepeltree <- function(x) {
       box.padding = x$box.padding,
       point.padding = x$point.padding,
       text.gp = gpar(
-        col = row$colour,
+        col = scales::alpha(row$colour, row$alpha),
         fontsize = row$size * .pt,
         fontfamily = row$family,
         fontface = row$fontface,
         lineheight = row$lineheight
       ),
       segment.gp = gpar(
-        col = x$segment.color,
+        col = scales::alpha(x$segment.color, row$alpha),
         lwd = x$segment.size * .pt
       ),
       arrow = x$arrow


### PR DESCRIPTION
Thanks a lot for this incredibly useful geom. I noticed the aesthetic `alpha` could not be used. Here is a pull-request that seems to fix it.

Thanks again!

PS: I'll be using `geom_text_repel` in the new version of multivariate analyses plots in autoplot: https://github.com/jiho/autoplot