### PR TITLE
Make the segment the same color as the text

### DIFF
--- a/R/geom-text-repel.R
+++ b/R/geom-text-repel.R
@@ -67,9 +67,9 @@
 #'   \code{unit(0.25, "lines")}.
 #' @param point.padding Amount of padding around labeled point. Defaults to
 #'   \code{unit(0, "lines")}.
-#' @param segment.color Color of the line segment connecting the data point to
-#'   the text labe. Defaults to \code{#666666}.
-#' @param segment.size Width of segment, in mm.
+#' @param segment.size Width of line segment connecting the data point to
+#'   the text label, in mm.
+#' @param segment.alpha Transparency of the segment, in \code{[0,1]}. Makes segments half transparent by default.
 #' @param arrow specification for arrow heads, as created by \code{\link[grid]{arrow}}
 #' @param force Force of repulsion between overlapping text labels. Defaults
 #'   to 1.
@@ -124,8 +124,8 @@ geom_text_repel <- function(
   ...,
   box.padding = unit(0.25, "lines"),
   point.padding = unit(1e-6, "lines"),
-  segment.color = "#666666",
   segment.size = 0.5,
+  segment.alpha = 0.5,
   arrow = NULL,
   force = 1,
   max.iter = 2000,
@@ -148,8 +148,8 @@ geom_text_repel <- function(
       na.rm = na.rm,
       box.padding = box.padding,
       point.padding = point.padding,
-      segment.color = segment.color,
       segment.size = segment.size,
+      segment.alpha = segment.alpha,
       arrow = arrow,
       force = force,
       max.iter = max.iter,
@@ -170,7 +170,7 @@ GeomTextRepel <- ggproto("GeomTextRepel", Geom,
 
   default_aes = aes(
     colour = "black", size = 3.88, angle = 0,
-    alpha = NA, family = "", fontface = 1, lineheight = 1.2
+    alpha = 1, family = "", fontface = 1, lineheight = 1.2
   ),
 
   draw_panel = function(
@@ -179,8 +179,8 @@ GeomTextRepel <- ggproto("GeomTextRepel", Geom,
     na.rm = FALSE,
     box.padding = unit(0.25, "lines"),
     point.padding = unit(1e-6, "lines"),
-    segment.color = "#666666",
     segment.size = 0.5,
+    segment.alpha = 0.5,
     arrow = NULL,
     force = 1,
     max.iter = 2000,
@@ -218,8 +218,8 @@ GeomTextRepel <- ggproto("GeomTextRepel", Geom,
       nudges = nudges,
       box.padding = box.padding,
       point.padding = point.padding,
-      segment.color = segment.color,
       segment.size = segment.size,
+      segment.alpha = segment.alpha,
       arrow = arrow,
       force = force,
       max.iter = max.iter,
@@ -282,6 +282,7 @@ makeContent.textrepeltree <- function(x) {
 
   grobs <- lapply(1:nrow(x$data), function(i) {
     row <- x$data[i, , drop = FALSE]
+    # browser()
     textRepelGrob(
       x$lab[i],
       x = unit(repel$x[i], "native"),
@@ -298,7 +299,7 @@ makeContent.textrepeltree <- function(x) {
         lineheight = row$lineheight
       ),
       segment.gp = gpar(
-        col = scales::alpha(x$segment.color, row$alpha),
+        col = scales::alpha(row$colour, row$alpha * x$segment.alpha),
         lwd = x$segment.size * .pt
       ),
       arrow = x$arrow

--- a/man/geom_text_repel.Rd
+++ b/man/geom_text_repel.Rd
@@ -15,8 +15,8 @@ geom_label_repel(mapping = NULL, data = NULL, stat = "identity",
 
 geom_text_repel(mapping = NULL, data = NULL, stat = "identity",
   parse = FALSE, ..., box.padding = unit(0.25, "lines"),
-  point.padding = unit(1e-06, "lines"), segment.color = "#666666",
-  segment.size = 0.5, arrow = NULL, force = 1, max.iter = 2000,
+  point.padding = unit(1e-06, "lines"), segment.size = 0.5,
+  segment.alpha = 0.5, arrow = NULL, force = 1, max.iter = 2000,
   nudge_x = 0, nudge_y = 0, na.rm = FALSE, show.legend = NA,
   inherit.aes = TRUE)
 }
@@ -59,10 +59,8 @@ displayed as described in ?plotmath}
 
 \item{label.size}{Size of label border, in mm.}
 
-\item{segment.color}{Color of the line segment connecting the data point to
-the text labe. Defaults to \code{#666666}.}
-
-\item{segment.size}{Width of segment, in mm.}
+\item{segment.size}{Width of line segment connecting the data point to
+the text label, in mm.}
 
 \item{arrow}{specification for arrow heads, as created by \code{\link[grid]{arrow}}}
 
@@ -86,6 +84,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
 the default plot specification, e.g. \code{\link[ggplot2]{borders}}.}
+
+\item{segment.alpha}{Transparency of the segment, in \code{[0,1]}. Makes segments half transparent by default.}
 }
 \description{
 \code{geom_text_repel} adds text directly to the plot.


### PR DESCRIPTION
Instead of setting segment.color to a mid-level grey, make it a bit
transparent and color it according to the color of the text. By default
the text is black and the half-transparent segment therefore still
appears grey.

When the text itself is made transparent, the transparency of the text
and of the segment are combined (multiplied).

Another possibility would be to declare two new *mappable* aesthetics:
segment.color and segment.alpha, and let the user do the mapping (i.e.
geom_text_repel(color=x, segment.color=x)) which would allow to color
the text and segment separately. But I find it quite cumbersome for a
small gain in versatility.