### PR TITLE
Make nudge_x and nudge_y into aesthetics

### DIFF
--- a/R/geom-label-repel.R
+++ b/R/geom-label-repel.R
@@ -17,8 +17,6 @@ geom_label_repel <- function(
   arrow = NULL,
   force = 1,
   max.iter = 2000,
-  nudge_x = 0,
-  nudge_y = 0,
   na.rm = FALSE,
   show.legend = NA,
   inherit.aes = TRUE
@@ -44,8 +42,6 @@ geom_label_repel <- function(
       na.rm = na.rm,
       force = force,
       max.iter = max.iter,
-      nudge_x = nudge_x,
-      nudge_y = nudge_y,
       ...
     )
   )
@@ -62,7 +58,8 @@ GeomLabelRepel <- ggproto(
 
   default_aes = aes(
     colour = "black", fill = "white", size = 3.88, angle = 0,
-    alpha = NA, family = "", fontface = 1, lineheight = 1.2
+    alpha = NA, family = "", fontface = 1, lineheight = 1.2,
+    nudge_x = 0, nudge_y = 0
   ),
 
   draw_panel = function(
@@ -78,9 +75,7 @@ GeomLabelRepel <- ggproto(
     segment.size = 0.5,
     arrow = NULL,
     force = 1,
-    max.iter = 2000,
-    nudge_x = 0,
-    nudge_y = 0
+    max.iter = 2000
   ) {
     lab <- data$label
     if (parse) {
@@ -93,7 +88,7 @@ GeomLabelRepel <- ggproto(
 
     # Transform the nudges to the panel scales.
     nudges <- data.frame(
-      x = data$x + nudge_x, y = data$y + nudge_y
+      x = data$x + data$nudge_x, y = data$y + data$nudge_y
     )
     nudges <- coord$transform(nudges, panel_scales)
 

--- a/R/geom-text-repel.R
+++ b/R/geom-text-repel.R
@@ -153,8 +153,6 @@ geom_text_repel <- function(
       arrow = arrow,
       force = force,
       max.iter = max.iter,
-      nudge_x = nudge_x,
-      nudge_y = nudge_y,
       ...
     )
   )
@@ -170,7 +168,8 @@ GeomTextRepel <- ggproto("GeomTextRepel", Geom,
 
   default_aes = aes(
     colour = "black", size = 3.88, angle = 0,
-    alpha = NA, family = "", fontface = 1, lineheight = 1.2
+    alpha = NA, family = "", fontface = 1, lineheight = 1.2,
+    nudge_x = 0, nudge_y = 0
   ),
 
   draw_panel = function(
@@ -183,9 +182,7 @@ GeomTextRepel <- ggproto("GeomTextRepel", Geom,
     segment.size = 0.5,
     arrow = NULL,
     force = 1,
-    max.iter = 2000,
-    nudge_x = 0,
-    nudge_y = 0
+    max.iter = 2000
   ) {
     lab <- data$label
     if (parse) {
@@ -198,7 +195,7 @@ GeomTextRepel <- ggproto("GeomTextRepel", Geom,
 
     # Transform the nudges to the panel scales.
     nudges <- data.frame(
-      x = data$x + nudge_x, y = data$y + nudge_y
+      x = data$x + data$nudge_x, y = data$y + data$nudge_y
       # x = rep_len(nudge_x, nrow(data)),
       # y = rep_len(nudge_y, nrow(data))
     )

--- a/man/geom_text_repel.Rd
+++ b/man/geom_text_repel.Rd
@@ -10,8 +10,8 @@ geom_label_repel(mapping = NULL, data = NULL, stat = "identity",
   label.padding = unit(0.25, "lines"), point.padding = unit(1e-06, "lines"),
   label.r = unit(0.15, "lines"), label.size = 0.25,
   segment.color = "#666666", segment.size = 0.5, arrow = NULL,
-  force = 1, max.iter = 2000, nudge_x = 0, nudge_y = 0, na.rm = FALSE,
-  show.legend = NA, inherit.aes = TRUE)
+  force = 1, max.iter = 2000, na.rm = FALSE, show.legend = NA,
+  inherit.aes = TRUE)
 
 geom_text_repel(mapping = NULL, data = NULL, stat = "identity",
   parse = FALSE, ..., box.padding = unit(0.25, "lines"),
@@ -72,9 +72,6 @@ to 1.}
 \item{max.iter}{Maximum number of iterations to try to resolve overlaps.
 Defaults to 2000.}
 
-\item{nudge_x, nudge_y}{Horizontal and vertical adjustments to nudge the
-starting position of each text label.}
-
 \item{na.rm}{If \code{FALSE} (the default), removes missing values with
 a warning.  If \code{TRUE} silently removes missing values.}
 
@@ -86,6 +83,9 @@ a warning.  If \code{TRUE} silently removes missing values.}
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
 the default plot specification, e.g. \code{\link[ggplot2]{borders}}.}
+
+\item{nudge_x, nudge_y}{Horizontal and vertical adjustments to nudge the
+starting position of each text label.}
 }
 \description{
 \code{geom_text_repel} adds text directly to the plot.
@@ -102,8 +102,7 @@ here.
 Text labels have height and width, but they are physical units, not data
 units. The amount of space they occupy on that plot is not constant in data
 units: when you resize a plot, labels stay the same size, but the size of
-the axes changes. Currently, the text labels will not be repositioned upon
-resizing a plot. This may change in future releases.
+the axes changes. The text labels are repositioned after resizing a plot.
 }
 \section{\code{geom_label_repel}}{
 

--- a/vignettes/ggrepel.Rmd
+++ b/vignettes/ggrepel.Rmd
@@ -106,7 +106,9 @@ ggplot(mtcars) +
     aes(
       wt, mpg,
       color = factor(cyl),
-      label = rownames(mtcars)
+      label = rownames(mtcars),
+      nudge_x = ifelse(mtcars$cyl == 6, 1, 0),
+      nudge_y = ifelse(mtcars$cyl == 6, 8, 0)
     ),
     size = 5,
     fontface = 'bold',
@@ -117,8 +119,6 @@ ggplot(mtcars) +
     arrow = arrow(length = unit(0.01, 'npc')),
     force = 1,
     max.iter = 2e3,
-    nudge_x = ifelse(mtcars$cyl == 6, 1, 0),
-    nudge_y = ifelse(mtcars$cyl == 6, 8, 0)
   ) +
   scale_color_discrete(name = 'cyl') +
   theme_classic(base_size = 16)


### PR DESCRIPTION
Fixes #27.

I branched this off from 580ddd8 because the subsequent commits seem incomplete and don't currently build. It makes `nudge_x` and `nudge_y` usable as aesthetics.