### PR TITLE
Finish adding segment.alpha

### DIFF
--- a/R/geom-label-repel.R
+++ b/R/geom-label-repel.R
@@ -12,8 +12,8 @@ geom_label_repel <- function(
   point.padding = unit(1e-6, "lines"),
   label.r = unit(0.15, "lines"),
   label.size = 0.25,
-  segment.color = "#666666",
   segment.size = 0.5,
+  segment.alpha = 0.5,
   arrow = NULL,
   force = 1,
   max.iter = 2000,
@@ -38,8 +38,8 @@ geom_label_repel <- function(
       point.padding  = point.padding,
       label.r = label.r,
       label.size = label.size,
-      segment.color = segment.color,
       segment.size = segment.size,
+      segment.alpha = segment.alpha,
       arrow = arrow,
       na.rm = na.rm,
       force = force,
@@ -62,7 +62,7 @@ GeomLabelRepel <- ggproto(
 
   default_aes = aes(
     colour = "black", fill = "white", size = 3.88, angle = 0,
-    alpha = NA, family = "", fontface = 1, lineheight = 1.2
+    alpha = 1, family = "", fontface = 1, lineheight = 1.2
   ),
 
   draw_panel = function(
@@ -74,8 +74,8 @@ GeomLabelRepel <- ggproto(
     point.padding = unit(1e-6, "lines"),
     label.r = unit(0.15, "lines"),
     label.size = 0.25,
-    segment.color = "#666666",
     segment.size = 0.5,
+    segment.alpha = 0.5,
     arrow = NULL,
     force = 1,
     max.iter = 2000,
@@ -114,8 +114,8 @@ GeomLabelRepel <- ggproto(
       point.padding = point.padding,
       label.r = label.r,
       label.size = label.size,
-      segment.color = segment.color,
       segment.size = segment.size,
+      segment.alpha = segment.alpha,
       arrow = arrow,
       force = force,
       max.iter = max.iter,
@@ -214,7 +214,7 @@ makeContent.labelrepeltree <- function(x) {
         lwd = x$label.size * .pt
       ),
       segment.gp = gpar(
-        col = x$segment.color,
+        col = scales::alpha(row$colour, row$alpha * x$segment.alpha),
         lwd = x$segment.size * .pt
       ),
       arrow = x$arrow

--- a/man/geom_text_repel.Rd
+++ b/man/geom_text_repel.Rd
@@ -8,10 +8,10 @@
 geom_label_repel(mapping = NULL, data = NULL, stat = "identity",
   parse = FALSE, ..., box.padding = unit(0.25, "lines"),
   label.padding = unit(0.25, "lines"), point.padding = unit(1e-06, "lines"),
-  label.r = unit(0.15, "lines"), label.size = 0.25,
-  segment.color = "#666666", segment.size = 0.5, arrow = NULL,
-  force = 1, max.iter = 2000, nudge_x = 0, nudge_y = 0, na.rm = FALSE,
-  show.legend = NA, inherit.aes = TRUE)
+  label.r = unit(0.15, "lines"), label.size = 0.25, segment.size = 0.5,
+  segment.alpha = 0.5, arrow = NULL, force = 1, max.iter = 2000,
+  nudge_x = 0, nudge_y = 0, na.rm = FALSE, show.legend = NA,
+  inherit.aes = TRUE)
 
 geom_text_repel(mapping = NULL, data = NULL, stat = "identity",
   parse = FALSE, ..., box.padding = unit(0.25, "lines"),
@@ -62,6 +62,8 @@ displayed as described in ?plotmath}
 \item{segment.size}{Width of line segment connecting the data point to
 the text label, in mm.}
 
+\item{segment.alpha}{Transparency of the segment, in \code{[0,1]}. Makes segments half transparent by default.}
+
 \item{arrow}{specification for arrow heads, as created by \code{\link[grid]{arrow}}}
 
 \item{force}{Force of repulsion between overlapping text labels. Defaults
@@ -84,8 +86,6 @@ a warning.  If \code{TRUE} silently removes missing values.}
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
 the default plot specification, e.g. \code{\link[ggplot2]{borders}}.}
-
-\item{segment.alpha}{Transparency of the segment, in \code{[0,1]}. Makes segments half transparent by default.}
 }
 \description{
 \code{geom_text_repel} adds text directly to the plot.
@@ -102,8 +102,7 @@ here.
 Text labels have height and width, but they are physical units, not data
 units. The amount of space they occupy on that plot is not constant in data
 units: when you resize a plot, labels stay the same size, but the size of
-the axes changes. Currently, the text labels will not be repositioned upon
-resizing a plot. This may change in future releases.
+the axes changes. The text labels are repositioned after resizing a plot.
 }
 \section{\code{geom_label_repel}}{
 

--- a/vignettes/ggrepel.Rmd
+++ b/vignettes/ggrepel.Rmd
@@ -87,7 +87,7 @@ However, the following parameters are not supported:
 
 `ggrepel` provides additional parameters for `geom_text_repel` and `geom_label_repel`:
 
-- `segment.color` is the line segment color
+- `segment.alpha` is the line segment alpha (transparency)
 - `box.padding` is the padding surrounding the text bounding box
 - `point.padding` is the padding around the labeled point
 - `arrow` is the specification for arrow heads created by `grid::arrow`
@@ -112,7 +112,6 @@ ggplot(mtcars) +
     fontface = 'bold',
     box.padding = unit(0.5, 'lines'),
     point.padding = unit(1.6, 'lines'),
-    segment.color = '#555555',
     segment.size = 0.5,
     arrow = arrow(length = unit(0.01, 'npc')),
     force = 1,
@@ -153,7 +152,7 @@ ggplot(Orange, aes(age, circumference, color = Tree)) +
     aes(label = paste("Tree", Tree)),
     size = 6,
     nudge_x = 45,
-    segment.color = NA
+    segment.alpha = 0
   ) +
   theme_classic(base_size = 16) +
   theme(legend.position = "none") +


### PR DESCRIPTION
Previous commits cbd205e and 0db788e removed segment.color from, and
added segment.alpha to, geom-text-repel.R. However, they did not
likewise modify geom-label-repel.R or the docs/vignettes. This commit
fixes that and makes the package build again.