### PR TITLE
Apply nudge when outside of aes

### DIFF
--- a/R/geom-text-repel.R
+++ b/R/geom-text-repel.R
@@ -129,8 +129,6 @@ geom_text_repel <- function(
   arrow = NULL,
   force = 1,
   max.iter = 2000,
-  nudge_x = 0,
-  nudge_y = 0,
   na.rm = FALSE,
   show.legend = NA,
   inherit.aes = TRUE


### PR DESCRIPTION
```r
library(ggrepel)
set.seed(1)
df <- data.frame(x=rnorm(50, 10), y=rep(c(0, 1), 25))
ggplot(df, aes(x=x, y=y)) + geom_point() + geom_text_repel(aes(label=round(x, 2), nudge_y=.5))
ggplot(df, aes(x=x, y=y)) + geom_point() + geom_text_repel(aes(label=round(x, 2)), nudge_y=.5)
```
