### PR TITLE
Label limits

### DIFF
--- a/R/geom-label-repel.R
+++ b/R/geom-label-repel.R
@@ -22,6 +22,8 @@ geom_label_repel <- function(
   max.iter = 2000,
   nudge_x = 0,
   nudge_y = 0,
+  xlim=c(NA,NA),
+  ylim=c(NA,NA),
   na.rm = FALSE,
   show.legend = NA,
   inherit.aes = TRUE
@@ -51,6 +53,8 @@ geom_label_repel <- function(
       max.iter = max.iter,
       nudge_x = nudge_x,
       nudge_y = nudge_y,
+      xlim = xlim,
+      ylim = ylim,
       ...
     )
   )
@@ -87,6 +91,8 @@ GeomLabelRepel <- ggproto(
     force = 1,
     nudge_x = 0,
     nudge_y = 0,
+    xlim=xlim,
+    ylim=ylim,
     max.iter = 2000
   ) {
     lab <- data$label
@@ -108,8 +114,16 @@ GeomLabelRepel <- ggproto(
     nudges$x <- nudges$x - data$x
     nudges$y <- nudges$y - data$y
 
+    # Transform limits to panel scales
+    limits <- data.frame(x=xlim, y=ylim)
+    limits <- coord$transform(limits, panel_scales)
+
+    # Fill NAs with defaults
+    limits$x[is.na(limits$x)] <- c(0, 1)[is.na(limits$x)]
+    limits$y[is.na(limits$y)] <- c(0, 1)[is.na(limits$y)]
+
     ggname("geom_label_repel", gTree(
-      limits = data.frame(x = c(0, 1), y = c(0, 1)),
+      limits = limits,
       data = data,
       lab = lab,
       nudges = nudges,

--- a/R/geom-text-repel.R
+++ b/R/geom-text-repel.R
@@ -165,8 +165,8 @@ geom_text_repel <- function(
   max.iter = 2000,
   nudge_x = 0,
   nudge_y = 0,
-  xlimits=c(0, 1),
-  ylimits=c(0, 1),
+  limits.x=c(0, 1),
+  limits.y=c(0, 1),
   na.rm = FALSE,
   show.legend = NA,
   inherit.aes = TRUE
@@ -193,8 +193,8 @@ geom_text_repel <- function(
       max.iter = max.iter,
       nudge_x = nudge_x,
       nudge_y = nudge_y,
-      xlimits = xlimits,
-      ylimits = ylimits,
+      limits.x = limits.x,
+      limits.y = limits.y,
       ...
     )
   )
@@ -228,8 +228,8 @@ GeomTextRepel <- ggproto("GeomTextRepel", Geom,
     max.iter = 2000,
     nudge_x = 0,
     nudge_y = 0,
-    xlimits=xlimits,
-    ylimits=ylimits
+    limits.x=limits.x,
+    limits.y=limits.y
   ) {
     lab <- data$label
     if (parse) {
@@ -251,7 +251,7 @@ GeomTextRepel <- ggproto("GeomTextRepel", Geom,
     nudges$y <- nudges$y - data$y
 
     ggname("geom_text_repel", gTree(
-      limits = data.frame(x = xlimits, y = ylimits),
+      limits = data.frame(x = limits.x, y = limits.y),
       data = data,
       lab = lab,
       nudges = nudges,

--- a/R/geom-text-repel.R
+++ b/R/geom-text-repel.R
@@ -165,8 +165,8 @@ geom_text_repel <- function(
   max.iter = 2000,
   nudge_x = 0,
   nudge_y = 0,
-  limits.x=c(0, 1),
-  limits.y=c(0, 1),
+  limits.x=c(NA,NA),
+  limits.y=c(NA,NA),
   na.rm = FALSE,
   show.legend = NA,
   inherit.aes = TRUE
@@ -250,8 +250,16 @@ GeomTextRepel <- ggproto("GeomTextRepel", Geom,
     nudges$x <- nudges$x - data$x
     nudges$y <- nudges$y - data$y
 
+    # Transform limits to panel scales
+    limits <- data.frame(x=limits.x, y=limits.y)
+    limits <- coord$transform(limits, panel_scales)
+
+    # Fill NAs with defaults
+    limits$x[is.na(limits$x)] <- c(0, 1)[is.na(limits$x)]
+    limits$y[is.na(limits$y)] <- c(0, 1)[is.na(limits$y)]
+
     ggname("geom_text_repel", gTree(
-      limits = data.frame(x = limits.x, y = limits.y),
+      limits = limits,
       data = data,
       lab = lab,
       nudges = nudges,

--- a/R/geom-text-repel.R
+++ b/R/geom-text-repel.R
@@ -165,8 +165,8 @@ geom_text_repel <- function(
   max.iter = 2000,
   nudge_x = 0,
   nudge_y = 0,
-  limits.x=c(NA,NA),
-  limits.y=c(NA,NA),
+  xlim=c(NA,NA),
+  ylim=c(NA,NA),
   na.rm = FALSE,
   show.legend = NA,
   inherit.aes = TRUE
@@ -193,8 +193,8 @@ geom_text_repel <- function(
       max.iter = max.iter,
       nudge_x = nudge_x,
       nudge_y = nudge_y,
-      limits.x = limits.x,
-      limits.y = limits.y,
+      xlim = xlim,
+      ylim = ylim,
       ...
     )
   )
@@ -228,8 +228,8 @@ GeomTextRepel <- ggproto("GeomTextRepel", Geom,
     max.iter = 2000,
     nudge_x = 0,
     nudge_y = 0,
-    limits.x=limits.x,
-    limits.y=limits.y
+    xlim=xlim,
+    ylim=ylim
   ) {
     lab <- data$label
     if (parse) {
@@ -251,7 +251,7 @@ GeomTextRepel <- ggproto("GeomTextRepel", Geom,
     nudges$y <- nudges$y - data$y
 
     # Transform limits to panel scales
-    limits <- data.frame(x=limits.x, y=limits.y)
+    limits <- data.frame(x=xlim, y=ylim)
     limits <- coord$transform(limits, panel_scales)
 
     # Fill NAs with defaults

--- a/R/geom-text-repel.R
+++ b/R/geom-text-repel.R
@@ -165,6 +165,8 @@ geom_text_repel <- function(
   max.iter = 2000,
   nudge_x = 0,
   nudge_y = 0,
+  xlimits=c(0, 1),
+  ylimits=c(0, 1),
   na.rm = FALSE,
   show.legend = NA,
   inherit.aes = TRUE
@@ -191,6 +193,8 @@ geom_text_repel <- function(
       max.iter = max.iter,
       nudge_x = nudge_x,
       nudge_y = nudge_y,
+      xlimits = xlimits,
+      ylimits = ylimits,
       ...
     )
   )
@@ -223,7 +227,9 @@ GeomTextRepel <- ggproto("GeomTextRepel", Geom,
     force = 1,
     max.iter = 2000,
     nudge_x = 0,
-    nudge_y = 0
+    nudge_y = 0,
+    xlimits=xlimits,
+    ylimits=ylimits
   ) {
     lab <- data$label
     if (parse) {
@@ -245,7 +251,7 @@ GeomTextRepel <- ggproto("GeomTextRepel", Geom,
     nudges$y <- nudges$y - data$y
 
     ggname("geom_text_repel", gTree(
-      limits = data.frame(x = c(0, 1), y = c(0, 1)),
+      limits = data.frame(x = xlimits, y = ylimits),
       data = data,
       lab = lab,
       nudges = nudges,

--- a/vignettes/ggrepel.Rmd
+++ b/vignettes/ggrepel.Rmd
@@ -223,11 +223,13 @@ ggplot() +
   geom_text_repel(
     data = left,
     mapping = aes(wt, mpg, label = rownames(left), colour = 'Left half'),
+    # Limit labels to the left of the vertical x=mu line
     xlim = c(NA, mu)
   ) +
   geom_text_repel(
     data = right,
     mapping = aes(wt, mpg, label = rownames(right), colour = 'Right half'),
+    # Limit labels to the right of the vertical x=mu line
     xlim = c(mu, NA)
   ) +
   theme_classic(base_size = 16)

--- a/vignettes/ggrepel.Rmd
+++ b/vignettes/ggrepel.Rmd
@@ -117,7 +117,7 @@ However, the following parameters are not supported:
   the x axis
 - `nudge_y` is how much to shift the starting position of the text label along
   the y axis
-  
+
 Here is an example that uses all of these options:
 
 ```{r geom_text_repel_options, echo=TRUE, fig.width=9, fig.height=7}
@@ -198,6 +198,39 @@ ggplot(mtcars, aes(wt, mpg)) +
     nudge_y = 0.1
   ) +
   theme_bw(base_size = 16)
+```
+
+### Limit labels to a specific area
+
+Use `xlim` and `ylim` parameters to specify the area to contain the labels in.
+Limits are specified in data coordinates, use `NA` if there is no lower/upper
+bound in a particular direction.
+
+```{r label-limits, echo=TRUE, fig.width=9, fig.height=7}
+set.seed(42)
+data <- mtcars
+mu <- mean(data$wt)
+
+left <- data[data$wt < mu,]
+right <- data[data$wt >= mu,]
+
+ggplot() +
+  geom_vline(xintercept = mu) +
+  geom_point(
+    data = data,
+    mapping = aes(wt, mpg)
+  ) +
+  geom_text_repel(
+    data = left,
+    mapping = aes(wt, mpg, label = rownames(left), colour = 'Left half'),
+    xlim = c(NA, mu)
+  ) +
+  geom_text_repel(
+    data = right,
+    mapping = aes(wt, mpg, label = rownames(right), colour = 'Right half'),
+    xlim = c(mu, NA)
+  ) +
+  theme_classic(base_size = 16)
 ```
 
 ### Line plot


### PR DESCRIPTION
Implements custom limits for label limits as discussed in #66 .
Takes the parameters `limits.x` and `limits.y` to be a vector with two elements, the first one being the lower limit, and the other one being the higher one. 
The vectors are in data coordinates.
NAs in the vector are replaced to the image lower or upper bounds respectively.

Usage example:

```R
library(ggrepel)
set.seed(42)
data <- mtcars
mu <- mean(data$wt)

left <- data[data$wt < mu,]
right <- data[data$wt >= mu,]

ggplot(data) +
  geom_vline(aes(xintercept=mu)) +
  geom_point(aes(wt, mpg), color = 'red') +
  geom_text_repel(aes(wt, mpg, label = rownames(left), colour='Left half'),
                  data=left,
                  limits.x=c(NA, mu)) +
  geom_text_repel(aes(wt, mpg, label = rownames(right), colour='Right half'),
                  data=right,
                  limits.x=c(mu, NA)) +
  theme_classic(base_size = 16)

ggsave('example.png')
```

Result:

![example](https://cloud.githubusercontent.com/assets/108413/21726711/c9dd12ae-d435-11e6-9315-095951273fa7.png)

