### PR TITLE
update ggproto defaults to fix #72

### DIFF
--- a/R/geom-label-repel.R
+++ b/R/geom-label-repel.R
@@ -93,8 +93,8 @@ GeomLabelRepel <- ggproto(
     force = 1,
     nudge_x = 0,
     nudge_y = 0,
-    xlim = xlim,
-    ylim = ylim,
+    xlim = NA_real_,
+    ylim = NA_real_,
     max.iter = 2000,
     direction = "both"
   ) {

--- a/R/geom-text-repel.R
+++ b/R/geom-text-repel.R
@@ -235,8 +235,8 @@ GeomTextRepel <- ggproto("GeomTextRepel", Geom,
     max.iter = 2000,
     nudge_x = 0,
     nudge_y = 0,
-    xlim = xlim,
-    ylim = ylim,
+    xlim = c(NA_real_, NA_real_),
+    ylim = c(NA_real_, NA_real_),
     direction = "both"
   ) {
     lab <- data$label


### PR DESCRIPTION
This originated with #67. The xlim and ylim did not have defaults. This wasn't picked up in the package itself because these defaults were provided in the `geom_*_repel()` functions. If a function is provided that doesn't explicitly set xlim and ylim, the ggproto goes into an infinite loop.

Here's an example that would fail without this PR:

``` r
library("ggrepel")
#> Loading required package: ggplot2
geom_my_text <- function(mapping = NULL, data = NULL, position = "identity", 
  parse = FALSE, check_overlap = FALSE, show.legend = NA, ...) {
  params <- list(parse = parse, na.rm = FALSE, ...)
  layer(data = data, mapping = mapping, stat = "identity", geom = ggrepel::GeomTextRepel, 
    position = position, show.legend = show.legend, inherit.aes = TRUE, 
    params = params)
}

df <- data.frame(list(x = c(15.5776938677355, 16.4702588232226, 16.3889534401047, 
  16.900129008757, 16.6651255573231), y = c(23.0855774870099, 22.4429678753689, 
  23.8278788673633, 21.1775152297959, 25.1328608218566), class = structure(c(1L, 
  2L, 2L, 2L, 2L))))

g <- ggplot(df, aes(x, y)) + geom_point()

x <- g + geom_text_repel(aes(label = class))

z <- g + geom_my_text(aes(label = class))

x + ggtitle("via geom_text_repel")
```

![](http://i.imgur.com/DV1rI8B.png)

``` r
z + ggtitle("via geom_my_text")
```

![](http://i.imgur.com/Di9c51d.png)

<details><summary>Session info</summary>

``` r
devtools::session_info()
#> Session info --------------------------------------------------------------
#>  setting  value                       
#>  version  R version 3.4.0 (2017-04-21)
#>  system   x86_64, darwin15.6.0        
#>  ui       X11                         
#>  language (EN)                        
#>  collate  en_US.UTF-8                 
#>  tz       America/Chicago             
#>  date     2017-05-10
#> Packages ------------------------------------------------------------------
#>  package    * version  date       source                            
#>  backports    1.0.5    2017-01-18 CRAN (R 3.4.0)                    
#>  bitops       1.0-6    2013-08-17 CRAN (R 3.4.0)                    
#>  colorspace   1.3-2    2016-12-14 CRAN (R 3.4.0)                    
#>  devtools     1.12.0   2016-12-05 CRAN (R 3.4.0)                    
#>  digest       0.6.12   2017-01-27 CRAN (R 3.4.0)                    
#>  evaluate     0.10     2016-10-11 CRAN (R 3.4.0)                    
#>  formatR      1.5      2017-04-25 CRAN (R 3.4.0)                    
#>  ggplot2    * 2.2.1    2016-12-30 CRAN (R 3.4.0)                    
#>  ggrepel    * 0.6.9    2017-05-10 Github (zkamvar/ggrepel@8fafadd)  
#>  gtable       0.2.0    2016-02-26 CRAN (R 3.4.0)                    
#>  htmltools    0.3.6    2017-04-28 CRAN (R 3.4.0)                    
#>  knitr        1.15.1   2016-11-22 CRAN (R 3.4.0)                    
#>  labeling     0.3      2014-08-23 CRAN (R 3.4.0)                    
#>  lazyeval     0.2.0    2016-06-12 CRAN (R 3.4.0)                    
#>  magrittr     1.5      2014-11-22 CRAN (R 3.4.0)                    
#>  memoise      1.1.0    2017-04-21 CRAN (R 3.4.0)                    
#>  munsell      0.4.3    2016-02-13 CRAN (R 3.4.0)                    
#>  plyr         1.8.4    2016-06-08 CRAN (R 3.4.0)                    
#>  Rcpp         0.12.10  2017-03-19 CRAN (R 3.4.0)                    
#>  RCurl        1.95-4.8 2016-03-01 CRAN (R 3.4.0)                    
#>  rmarkdown    1.5.9000 2017-05-07 Github (rstudio/rmarkdown@ca56f55)
#>  rprojroot    1.2      2017-01-16 CRAN (R 3.4.0)                    
#>  scales       0.4.1    2016-11-09 CRAN (R 3.4.0)                    
#>  stringi      1.1.5    2017-04-07 CRAN (R 3.4.0)                    
#>  stringr      1.2.0    2017-02-18 CRAN (R 3.4.0)                    
#>  tibble       1.3.0    2017-04-01 CRAN (R 3.4.0)                    
#>  withr        1.0.2    2016-06-20 CRAN (R 3.4.0)                    
#>  XML          3.98-1.7 2017-05-03 CRAN (R 3.4.0)                    
#>  yaml         2.1.14   2016-11-12 CRAN (R 3.4.0)
```

</details>