### PR TITLE
bug fix for geom_label_repel with subset of points labelled

### DIFF
--- a/R/geom-label-repel.R
+++ b/R/geom-label-repel.R
@@ -186,6 +186,7 @@ makeContent.labelrepeltree <- function(x) {
 
   # Do not create text labels for empty strings.
   valid_strings <- which(not_empty(x$lab))
+  invalid_strings <- which(!not_empty(x$lab))
 
   # Create a dataframe with x y width height
   boxes <- lapply(valid_strings, function(i) {
@@ -231,9 +232,14 @@ makeContent.labelrepeltree <- function(x) {
       set.seed(x$seed)
   }
 
+  points_valid_first <- cbind(c(x$data$x[valid_strings],
+                                x$data$x[invalid_strings]),
+                              c(x$data$y[valid_strings],
+                                x$data$y[invalid_strings]))
+
   # Repel overlapping bounding boxes away from each other.
   repel <- repel_boxes(
-    data_points = cbind(x$data$x, x$data$y),
+    data_points = points_valid_first,
     point_padding_x = point_padding_x,
     point_padding_y = point_padding_y,
     boxes = do.call(rbind, boxes),


### PR DESCRIPTION
Minimal PR to fix bug #92 that was introduced in #86 (Sorry!).  Issue is that line-crossing check expects points and labels to be in the same order; this was being violated in the case of not all points having labels. The work-around to make sure points and labels properly paired in repel_boxes was already implemented for geom_text_repel; now added to geom_label_repel.

 Checked that the minimal reprex from @slowkow described in #92 looks comparable to cran version:

![issue92](https://user-images.githubusercontent.com/6809790/34322411-59362b84-e7db-11e7-9a9e-7e49b3f92f9e.png)

Side Note:  I had to delete the RcppExports.cpp file and regenerate freshly to get this to build without a segfault (both pre- and post- the R changes made in this PR). This PR only includes the change to the R file though.
