### PR TITLE
Aabb: using only one tree seems to speed up each iteration

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -103,10 +103,10 @@ approximately_equal <- function(x1, x2) {
 #' @param ylim A numeric vector representing the limits on the y axis like
 #'   \code{c(ymin, ymax)}
 #' @param force Magnitude of the force (defaults to \code{1e-6})
-#' @param maxiter Maximum number of iterations to try to resolve overlaps
-#'   (defaults to 2000)
+#' @param max_time Maximum number of seconds to try to resolve overlaps
+#'   (defaults to 1.0)
 #' @noRd
-repel_boxes <- function(data_points, point_padding_x, point_padding_y, boxes, xlim, ylim, hjust, vjust, force_push = 1e-7, force_pull = 1e-7, maxiter = 2000L, direction = "both") {
-    .Call('_ggrepel_repel_boxes', PACKAGE = 'ggrepel', data_points, point_padding_x, point_padding_y, boxes, xlim, ylim, hjust, vjust, force_push, force_pull, maxiter, direction)
+repel_boxes <- function(data_points, point_padding_x, point_padding_y, boxes, xlim, ylim, hjust, vjust, force_push = 1e-7, force_pull = 1e-7, max_time = 1.0, max_iter = 1e5L, use_tree = TRUE, direction = "both") {
+    .Call('_ggrepel_repel_boxes', PACKAGE = 'ggrepel', data_points, point_padding_x, point_padding_y, boxes, xlim, ylim, hjust, vjust, force_push, force_pull, max_time, max_iter, use_tree, direction)
 }
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -104,9 +104,9 @@ approximately_equal <- function(x1, x2) {
 #'   \code{c(ymin, ymax)}
 #' @param force Magnitude of the force (defaults to \code{1e-6})
 #' @param max_time Maximum number of seconds to try to resolve overlaps
-#'   (defaults to 1.0)
+#'   (defaults to 0.1)
 #' @noRd
-repel_boxes <- function(data_points, point_padding_x, point_padding_y, boxes, xlim, ylim, hjust, vjust, force_push = 1e-7, force_pull = 1e-7, max_time = 1.0, max_iter = 1e5L, use_tree = TRUE, direction = "both") {
+repel_boxes <- function(data_points, point_padding_x, point_padding_y, boxes, xlim, ylim, hjust, vjust, force_push = 1e-7, force_pull = 1e-7, max_time = 0.1, max_iter = 1e5L, use_tree = TRUE, direction = "both") {
     .Call('_ggrepel_repel_boxes', PACKAGE = 'ggrepel', data_points, point_padding_x, point_padding_y, boxes, xlim, ylim, hjust, vjust, force_push, force_pull, max_time, max_iter, use_tree, direction)
 }
 

--- a/R/geom-label-repel.R
+++ b/R/geom-label-repel.R
@@ -25,6 +25,7 @@ geom_label_repel <- function(
   force = 1,
   force_pull = 1,
   max_time = 0.1,
+  max_iter = 1e5,
   nudge_x = 0,
   nudge_y = 0,
   xlim = c(NA, NA),
@@ -65,6 +66,7 @@ geom_label_repel <- function(
       force = force,
       force_pull = force_pull,
       max_time = max_time,
+      max_iter = max_iter,
       nudge_x = nudge_x,
       nudge_y = nudge_y,
       xlim = xlim,
@@ -112,6 +114,7 @@ GeomLabelRepel <- ggproto(
     xlim = c(NA, NA),
     ylim = c(NA, NA),
     max_time = 0.1,
+    max_iter = 1e5,
     direction = "both",
     seed = NA
   ) {
@@ -171,6 +174,7 @@ GeomLabelRepel <- ggproto(
       force = force,
       force_pull = force_pull,
       max_time = max_time,
+      max_iter = max_iter,
       direction = direction,
       seed = seed,
       cl = "labelrepeltree"
@@ -263,6 +267,7 @@ makeContent.labelrepeltree <- function(x) {
     force_push = x$force * 1e-6,
     force_pull = x$force_pull * 1e-2,
     max_time = x$max_time,
+    max_iter = x$max_iter,
     direction = x$direction
   )
 

--- a/R/geom-text-repel.R
+++ b/R/geom-text-repel.R
@@ -85,7 +85,7 @@
 #' @param force_pull Force of attraction between a text label and its
 #'   corresponding data point. Defaults to 1.
 #' @param max_time Maximum number of seconds to try to resolve overlaps.
-#'   Defaults to 0.1. 
+#'   Defaults to 0.1.
 #' @param direction "both", "x", or "y" -- direction in which to adjust position of labels
 #' @param seed Random seed passed to \code{\link[base]{set.seed}}. Defaults to
 #'   \code{NA}, which means that \code{set.seed} will not be called.
@@ -174,6 +174,7 @@ geom_text_repel <- function(
   force = 1,
   force_pull = 1,
   max_time = 0.1,
+  max_iter = 1e5,
   use_tree = FALSE,
   nudge_x = 0,
   nudge_y = 0,
@@ -212,6 +213,7 @@ geom_text_repel <- function(
       force = force,
       force_pull = force_pull,
       max_time = max_time,
+      max_iter = max_iter,
       use_tree = use_tree,
       nudge_x = nudge_x,
       nudge_y = nudge_y,
@@ -252,6 +254,7 @@ GeomTextRepel <- ggproto("GeomTextRepel", Geom,
     force = 1,
     force_pull = 1,
     max_time = 0.1,
+    max_iter = 1e5,
     use_tree = FALSE,
     nudge_x = 0,
     nudge_y = 0,
@@ -313,6 +316,7 @@ GeomTextRepel <- ggproto("GeomTextRepel", Geom,
       force = force,
       force_pull = force_pull,
       max_time = max_time,
+      max_iter = max_iter,
       use_tree = use_tree,
       direction = direction,
       seed = seed,
@@ -394,6 +398,7 @@ makeContent.textrepeltree <- function(x) {
     force_push = x$force * 1e-6,
     force_pull = x$force_pull * 1e-2,
     max_time = x$max_time,
+    max_iter = x$max_iter,
     use_tree = x$use_tree,
     direction = x$direction
   )

--- a/R/geom-text-repel.R
+++ b/R/geom-text-repel.R
@@ -86,6 +86,8 @@
 #'   corresponding data point. Defaults to 1.
 #' @param max_time Maximum number of seconds to try to resolve overlaps.
 #'   Defaults to 0.1.
+#'   @param max_iter Maximum number of iterations to try to resolve overlaps.
+#'   Defaults to 1e5.
 #' @param direction "both", "x", or "y" -- direction in which to adjust position of labels
 #' @param seed Random seed passed to \code{\link[base]{set.seed}}. Defaults to
 #'   \code{NA}, which means that \code{set.seed} will not be called.

--- a/man/geom_text_repel.Rd
+++ b/man/geom_text_repel.Rd
@@ -11,17 +11,17 @@ geom_label_repel(mapping = NULL, data = NULL, stat = "identity",
   label.size = 0.25, segment.colour = NULL, segment.color = NULL,
   segment.size = 0.5, segment.alpha = NULL, min.segment.length = 0.5,
   arrow = NULL, force = 1, force_pull = 1, max_time = 0.1,
-  nudge_x = 0, nudge_y = 0, xlim = c(NA, NA), ylim = c(NA, NA),
-  na.rm = FALSE, show.legend = NA, direction = c("both", "y", "x"),
-  seed = NA, inherit.aes = TRUE)
+  max_iter = 1e+05, nudge_x = 0, nudge_y = 0, xlim = c(NA, NA),
+  ylim = c(NA, NA), na.rm = FALSE, show.legend = NA,
+  direction = c("both", "y", "x"), seed = NA, inherit.aes = TRUE)
 
 geom_text_repel(mapping = NULL, data = NULL, stat = "identity",
   position = "identity", parse = FALSE, ..., box.padding = 0.25,
   point.padding = 1e-06, segment.colour = NULL, segment.color = NULL,
   segment.size = 0.5, segment.alpha = NULL, min.segment.length = 0.5,
   arrow = NULL, force = 1, force_pull = 1, max_time = 0.1,
-  use_tree = FALSE, nudge_x = 0, nudge_y = 0, xlim = c(NA, NA),
-  ylim = c(NA, NA), na.rm = FALSE, show.legend = NA,
+  max_iter = 1e+05, use_tree = FALSE, nudge_x = 0, nudge_y = 0,
+  xlim = c(NA, NA), ylim = c(NA, NA), na.rm = FALSE, show.legend = NA,
   direction = c("both", "y", "x"), seed = NA, inherit.aes = TRUE)
 }
 \arguments{
@@ -95,7 +95,9 @@ to 1.}
 corresponding data point. Defaults to 1.}
 
 \item{max_time}{Maximum number of seconds to try to resolve overlaps.
-Defaults to 0.1.}
+Defaults to 0.1.
+@param max_iter Maximum number of iterations to try to resolve overlaps.
+Defaults to 1e5.}
 
 \item{nudge_x, nudge_y}{Horizontal and vertical adjustments to nudge the
 starting position of each text label.}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -68,8 +68,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // repel_boxes
-DataFrame repel_boxes(NumericMatrix data_points, double point_padding_x, double point_padding_y, NumericMatrix boxes, NumericVector xlim, NumericVector ylim, NumericVector hjust, NumericVector vjust, double force_push, double force_pull, int maxiter, std::string direction);
-RcppExport SEXP _ggrepel_repel_boxes(SEXP data_pointsSEXP, SEXP point_padding_xSEXP, SEXP point_padding_ySEXP, SEXP boxesSEXP, SEXP xlimSEXP, SEXP ylimSEXP, SEXP hjustSEXP, SEXP vjustSEXP, SEXP force_pushSEXP, SEXP force_pullSEXP, SEXP maxiterSEXP, SEXP directionSEXP) {
+DataFrame repel_boxes(NumericMatrix data_points, double point_padding_x, double point_padding_y, NumericMatrix boxes, NumericVector xlim, NumericVector ylim, NumericVector hjust, NumericVector vjust, double force_push, double force_pull, double max_time, int max_iter, bool use_tree, std::string direction);
+RcppExport SEXP _ggrepel_repel_boxes(SEXP data_pointsSEXP, SEXP point_padding_xSEXP, SEXP point_padding_ySEXP, SEXP boxesSEXP, SEXP xlimSEXP, SEXP ylimSEXP, SEXP hjustSEXP, SEXP vjustSEXP, SEXP force_pushSEXP, SEXP force_pullSEXP, SEXP max_timeSEXP, SEXP max_iterSEXP, SEXP use_treeSEXP, SEXP directionSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -83,9 +83,11 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< NumericVector >::type vjust(vjustSEXP);
     Rcpp::traits::input_parameter< double >::type force_push(force_pushSEXP);
     Rcpp::traits::input_parameter< double >::type force_pull(force_pullSEXP);
-    Rcpp::traits::input_parameter< int >::type maxiter(maxiterSEXP);
+    Rcpp::traits::input_parameter< double >::type max_time(max_timeSEXP);
+    Rcpp::traits::input_parameter< int >::type max_iter(max_iterSEXP);
+    Rcpp::traits::input_parameter< bool >::type use_tree(use_treeSEXP);
     Rcpp::traits::input_parameter< std::string >::type direction(directionSEXP);
-    rcpp_result_gen = Rcpp::wrap(repel_boxes(data_points, point_padding_x, point_padding_y, boxes, xlim, ylim, hjust, vjust, force_push, force_pull, maxiter, direction));
+    rcpp_result_gen = Rcpp::wrap(repel_boxes(data_points, point_padding_x, point_padding_y, boxes, xlim, ylim, hjust, vjust, force_push, force_pull, max_time, max_iter, use_tree, direction));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -96,7 +98,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_ggrepel_intersect_line_rectangle", (DL_FUNC) &_ggrepel_intersect_line_rectangle, 3},
     {"_ggrepel_select_line_connection", (DL_FUNC) &_ggrepel_select_line_connection, 2},
     {"_ggrepel_approximately_equal", (DL_FUNC) &_ggrepel_approximately_equal, 2},
-    {"_ggrepel_repel_boxes", (DL_FUNC) &_ggrepel_repel_boxes, 12},
+    {"_ggrepel_repel_boxes", (DL_FUNC) &_ggrepel_repel_boxes, 14},
     {NULL, NULL, 0}
 };
 

--- a/src/repel_boxes.cpp
+++ b/src/repel_boxes.cpp
@@ -534,7 +534,7 @@ Point spring_force(
 //'   \code{c(ymin, ymax)}
 //' @param force Magnitude of the force (defaults to \code{1e-6})
 //' @param max_time Maximum number of seconds to try to resolve overlaps
-//'   (defaults to 1.0)
+//'   (defaults to 0.1)
 //' @noRd
 // [[Rcpp::export]]
 DataFrame repel_boxes(
@@ -545,7 +545,7 @@ DataFrame repel_boxes(
     NumericVector hjust, NumericVector vjust,
     double force_push = 1e-7,
     double force_pull = 1e-7,
-    double max_time = 1.0,
+    double max_time = 0.1,
     int max_iter = 1e5,
     bool use_tree = true,
     std::string direction = "both"


### PR DESCRIPTION
I've played with your code: it seems that using a single tree for both the points and the labels leads to a speed gain. Feel free to verify as this has not been fully tested.
I've also (re)introduced a max_iter parameter: this was easier to test the speed for a given number of iteration. Otherwise the hardcoded 1e5 limit should be removed...

Erwan