### PR TITLE
add shadowtext functionality to ggrepel

### DIFF
--- a/R/geom-text-repel.R
+++ b/R/geom-text-repel.R
@@ -225,7 +225,8 @@ GeomTextRepel <- ggproto("GeomTextRepel", Geom,
     alpha = NA, family = "", fontface = 1, lineheight = 1.2,
     hjust = 0.5, vjust = 0.5, point.size = 1,
     segment.linetype = 1, segment.colour = "black", segment.size = 0.5, segment.alpha = 1,
-    segment.curvature = 0, segment.angle = 90, segment.ncp = 1
+    segment.curvature = 0, segment.angle = 90, segment.ncp = 1,
+    bg.colour = NA, bg.r = 0.1
   ),
 
   draw_panel = function(
@@ -429,15 +430,18 @@ makeContent.textrepeltree <- function(x) {
       arrow = x$arrow,
       min.segment.length = x$min.segment.length,
       hjust = row$hjust,
-      vjust = row$vjust
+      vjust = row$vjust,
+      bg.colour = alpha(row$bg.colour, row$alpha),
+      bg.r = row$bg.r
     )
   })
-  # Put segment grobs before text grobs.
-  grobs <- c(
-    Filter(Negate(is.null), lapply(grobs, "[[", "segment")),
-    Filter(Negate(is.null), lapply(grobs, "[[", "text"))
-  )
+
+  # class(grobs) <- "gList"
+  grobs <- unlist(grobs, recursive = FALSE)
   class(grobs) <- "gList"
+
+  # Put segment grobs before text grobs.
+  grobs <- grobs[order(!grepl("^segment", names(grobs)), seq_along(grobs))]
 
   setChildren(x, grobs)
 }
@@ -467,7 +471,9 @@ makeTextRepelGrobs <- function(
   arrow = NULL,
   min.segment.length = 0.5,
   hjust = 0.5,
-  vjust = 0.5
+  vjust = 0.5,
+  bg.colour = NA,
+  bg.r = .1
 ) {
   stopifnot(length(label) == 1)
 
@@ -479,15 +485,19 @@ makeTextRepelGrobs <- function(
   hj <- resolveHJust(just, NULL)
   vj <- resolveVJust(just, NULL)
 
-  t <- textGrob(
+  grobs <- shadowtextGrob(
     label,
     x + 2 * (0.5 - hj) * box.padding,
     y + 2 * (0.5 - vj) * box.padding,
     rot = rot,
     just = c(hj, vj),
     gp = text.gp,
-    name = sprintf("textrepelgrob%s", i)
+    name = sprintf("textrepelgrob%s", i),
+    bg.colour = bg.colour,
+    bg.r = bg.r
   )
+  # the regular textgrob will always be the last one
+  t <- grobs[[length(grobs)]]
 
   x1 <- convertWidth(x - 0.5 * grobWidth(t), "native", TRUE)
   x2 <- convertWidth(x + 0.5 * grobWidth(t), "native", TRUE)
@@ -540,8 +550,6 @@ makeTextRepelGrobs <- function(
     min.segment.length <- sqrt((mx * dx / d) ^ 2 + (my * dy / d) ^ 2)
   }
 
-  grobs <- list(text = t)
-
   if (
     !point_inside_text &&
     d > 0 &&
@@ -567,7 +575,7 @@ makeTextRepelGrobs <- function(
       name = sprintf("segmentrepelgrob%s", i),
       arrow = arrow
     )
-    grobs[["segment"]] <- s
+    grobs[[s$name]] <- s
   }
 
   grobs
@@ -590,4 +598,45 @@ just_dir <- function(x, tol = 0.001) {
   out[x < 0.5 - tol] <- 1L
   out[x > 0.5 + tol] <- 3L
   out
+}
+
+# copied and slightly adapted from shadowtext
+shadowtextGrob <- function(
+  label, x = unit(0.5, "npc"), y = unit(0.5, "npc"),
+  just = "centre", hjust = NULL, vjust = NULL, rot = 0, check.overlap = FALSE,
+  default.units = "npc", name = NULL, gp = gpar(col="white"), vp = NULL,
+  bg.colour = "black", bg.r = 0.1
+) {
+  upperGrob <- textGrob(
+    label = label, x = x, y = y, just = just, hjust = hjust,
+    vjust = vjust, rot = rot, default.units = default.units,
+    check.overlap = check.overlap, name = name, gp = gp, vp = vp
+  )
+
+  if (is.na(bg.colour)) {
+    gList(upperGrob)
+  } else {
+    gp$col <- bg.colour
+
+    theta <- seq(pi/8, 2*pi, length.out=16)
+    char <- substring(label[1], 1, 1)
+    r <- bg.r[1]
+
+    bgList <- lapply(theta, function(i) {
+      if (!is.unit(x))
+        x <- unit(x, default.units)
+      if (!is.unit(y))
+        y <- unit(y, default.units)
+
+      x <- x + unit(cos(i) * r, "strwidth", data = char)
+      y <- y + unit(sin(i) * r, "strheight", data = char)
+      textGrob(
+        label = label, x = x, y = y, just = just, hjust = hjust,
+        vjust = vjust, rot = rot, default.units = default.units,
+        check.overlap = check.overlap, name = paste0(name, "-shadowtext", i), gp = gp, vp = vp
+      )
+    })
+
+    do.call(gList, c(bgList, list(upperGrob)))
+  }
 }

--- a/R/geom-text-repel.R
+++ b/R/geom-text-repel.R
@@ -619,7 +619,8 @@ shadowtextGrob <- function(
     gp$col <- bg.colour
 
     theta <- seq(pi/8, 2*pi, length.out=16)
-    char <- substring(label[1], 1, 1)
+    char <- "X"
+    # char <- substring(label[1], 1, 1)
     r <- bg.r[1]
 
     bgList <- lapply(theta, function(i) {
@@ -628,7 +629,7 @@ shadowtextGrob <- function(
       if (!is.unit(y))
         y <- unit(y, default.units)
 
-      x <- x + unit(cos(i) * r, "strwidth", data = char)
+      x <- x + unit(cos(i) * r, "strheight", data = char)
       y <- y + unit(sin(i) * r, "strheight", data = char)
       textGrob(
         label = label, x = x, y = y, just = just, hjust = hjust,

--- a/R/geom-text-repel.R
+++ b/R/geom-text-repel.R
@@ -436,12 +436,12 @@ makeContent.textrepeltree <- function(x) {
     )
   })
 
-  # class(grobs) <- "gList"
   grobs <- unlist(grobs, recursive = FALSE)
   class(grobs) <- "gList"
 
   # Put segment grobs before text grobs.
-  grobs <- grobs[order(!grepl("^segment", names(grobs)), seq_along(grobs))]
+  grob_names <- sapply(grobs, "[[", "name")
+  grobs <- grobs[order(!grepl("^segment", grob_names))]
 
   setChildren(x, grobs)
 }


### PR DESCRIPTION
Hello @slowkow!

This PR is related to issue #103, adding 'halos' to ggrepel. I looked at the shadowtext implementation and found that adding it to ggrepel would not be that difficult. At first, I simply reused the `shadowtext::shadowtextGrob()` function, but that would add an extra dependency to `ggrepel`. Since `shadowtextGrob()` is relatively simple, I instead copypasted it and changed it a little bit to make it work better with ggrepel.

The timings are in line with what is to be expected:
![out](https://user-images.githubusercontent.com/553642/68203774-dabdf380-ffc6-11e9-9fc9-782c0f8ea95c.png)

<details><summary>Code for timings</summary>

```r
# adapted from your code in issue #103
library(tidyverse)
library(ggrepel)
library(ggbeeswarm)
library(shadowtext)

# subset data
d <- diamonds[1:20,]

# make basic plot with no text
basic_plot <- 
  ggplot(d, aes(carat, price)) +
  geom_point()

plot_with_text <- 
  basic_plot + 
  geom_text(
    aes(label = cut),
    size = 6,
    colour = 'black',
  )

plot_with_halo_and_repel <- 
  basic_plot + 
  geom_text_repel(
    aes(label = cut),
    size = 6,
    colour = 'black', 
    seed = 1,
    segment.colour = "grey80",
    bg.colour = "white"
  )

# basic plot with geom_repel only 
plot_with_repel_only <- 
  basic_plot  + 
  geom_text_repel(
    aes(label = cut),
    size = 6,
    colour = 'black', 
    seed = 1,
    segment.colour = "grey80"
  )

# basic plot with geom_repel only 
plot_with_shadowtext_only <- 
  basic_plot  + 
  geom_shadowtext(
    aes(label = cut),
    size = 6,
    colour = 'black',
    bg.colour = "white"
  )

the_plots <- list(
  plot_with_text, # the basic plot
  plot_with_repel_only, # the plot with repel only
  plot_with_shadowtext_only, # the plot with the shadow pkg only
  plot_with_halo_and_repel # the plot with halo layers and repel
) 

the_output <- vector("list", length = length(the_plots))

benchplot_and_clear <- function(x){
  tmp <- benchplot(x)
  dev.off()
  gc()
  return(tmp)
}

for(i in 1:length(the_plots)){
  timings <- rerun(100, benchplot_and_clear(the_plots[[i]]))
  
  the_output[[i]] <- 
    timings %>% 
    bind_rows(.id = 'run') %>% 
    filter(step == "TOTAL")
  
  message(str_glue('done with plot {i}'))
  
}

the_output %>% 
  bind_rows(.id = "runs") %>% 
  ggplot(aes(runs, user.self)) +
  geom_boxplot() +
  geom_quasirandom(alpha = 0.2) +
  coord_flip() +
  scale_x_discrete(
    labels = c('basic plot',
               'plot with repel only',
               'plot with shadowtext only',
               'plot with shadowtext and repel')) +
  labs(x = "",
       y = "seconds") +
  theme_minimal(base_size = 14) +
  expand_limits(y = 0)
```
</details>

The only issue I still have is, where do I document this functionality? Since it's an aesthetic, it's not a parameter I can document with `@param bg.colour` and `@param bg.r`. Where do you think this documentation should end up?

Alternatively, I could create a separate function, `geom_shadowtext_repel()`. It could use the same underlying implementation, just with different default aesthetics (`bg.colour = NA, bg.r = .1` for `geom_text_repel()` and `bg.colour = "white", bg.r = .1` for `geom_shadowtext_repel`).

What are your thoughts on this?

Kind regards,
Robrecht