### PR TITLE
Support new naming (with minimal code edits)

### DIFF
--- a/R/geom-label-repel.R
+++ b/R/geom-label-repel.R
@@ -127,6 +127,17 @@ GeomLabelRepel <- ggproto(
       return()
     }
 
+    # as a test without disrupting anything, rename columns to names previously used
+    for (this_dim in c("x", "y")) {
+      this_orig <- sprintf("%s_orig", this_dim)
+      this_nudge <- sprintf("nudge_%s", this_dim)
+      if (this_orig %in% colnames(data)) {
+        data[[this_nudge]] <- data[[this_dim]]
+        data[[this_dim]] <- data[[this_orig]]
+        data[[this_orig]] <- NULL
+      }
+    }
+
     # position_nudge_repel() should have added these columns.
     for (this_dim in c("x", "y")) {
       this_nudge <- sprintf("nudge_%s", this_dim)

--- a/R/geom-text-repel.R
+++ b/R/geom-text-repel.R
@@ -269,24 +269,27 @@ GeomTextRepel <- ggproto("GeomTextRepel", Geom,
       return()
     }
 
-    # as a test without disrupting anything, rename columns to names previously used
+    # As a test without disrupting anything, rename columns to match old names
     for (this_dim in c("x", "y")) {
       this_orig <- sprintf("%s_orig", this_dim)
       this_nudge <- sprintf("nudge_%s", this_dim)
+      data[[this_nudge]] <- data[[this_dim]]
       if (this_orig %in% colnames(data)) {
-        data[[this_nudge]] <- data[[this_dim]]
         data[[this_dim]] <- data[[this_orig]]
         data[[this_orig]] <- NULL
       }
     }
 
-    # position_nudge_repel() should have added these columns.
-    for (this_dim in c("x", "y")) {
-      this_nudge <- sprintf("nudge_%s", this_dim)
-      if (!this_nudge %in% colnames(data)) {
-        data[[this_nudge]] <- data[[this_dim]]
-      }
-    }
+    ## Now redundant
+    #
+    # # position_nudge_repel() should have added these columns.
+    # for (this_dim in c("x", "y")) {
+    #   this_nudge <- sprintf("nudge_%s", this_dim)
+    #   if (!this_nudge %in% colnames(data)) {
+    #     data[[this_nudge]] <- data[[this_dim]]
+    #   }
+    # }
+
     # Transform the nudges to the panel scales.
     nudges <- data.frame(x = data$nudge_x, y = data$nudge_y)
     nudges <- coord$transform(nudges, panel_scales)

--- a/R/geom-text-repel.R
+++ b/R/geom-text-repel.R
@@ -269,6 +269,17 @@ GeomTextRepel <- ggproto("GeomTextRepel", Geom,
       return()
     }
 
+    # as a test without disrupting anything, rename columns to names previously used
+    for (this_dim in c("x", "y")) {
+      this_orig <- sprintf("%s_orig", this_dim)
+      this_nudge <- sprintf("nudge_%s", this_dim)
+      if (this_orig %in% colnames(data)) {
+        data[[this_nudge]] <- data[[this_dim]]
+        data[[this_dim]] <- data[[this_orig]]
+        data[[this_orig]] <- NULL
+      }
+    }
+
     # position_nudge_repel() should have added these columns.
     for (this_dim in c("x", "y")) {
       this_nudge <- sprintf("nudge_%s", this_dim)

--- a/R/position-nudge-repel.R
+++ b/R/position-nudge-repel.R
@@ -92,10 +92,8 @@ PositionNudgeRepel <- ggproto("PositionNudgeRepel", Position,
     } else if (any(params$y != 0)) {
       data <- transform_position(data, NULL, function(y) y + params$y)
     }
-    data$nudge_x <- data$x
-    data$nudge_y <- data$y
-    data$x <- x_orig
-    data$y <- y_orig
+    data$x_orig <- x_orig
+    data$y_orig <- y_orig
     data
   }
 )

--- a/man/ggrepel.Rd
+++ b/man/ggrepel.Rd
@@ -50,7 +50,7 @@ Other contributors:
   \item Amir Masoud Abdol [contributor]
   \item Malcolm Barrett (\href{https://orcid.org/0000-0003-0299-5825}{ORCID}) [contributor]
   \item Robrecht Cannoodt (\href{https://orcid.org/0000-0003-3641-729X}{ORCID}) [contributor]
-  \item Michal Krassowski (\href{https://orcid.org/0000-0002-9638-7785}{ORCID}) [contributor]
+  \item Michał Krassowski (\href{https://orcid.org/0000-0002-9638-7785}{ORCID}) [contributor]
   \item Michael Chirico (\href{https://orcid.org/0000-0003-0787-087X}{ORCID}) [contributor]
   \item Pedro Aphalo (\href{https://orcid.org/0000-0003-3385-972X}{ORCID}) [contributor]
 }

--- a/man/ggrepel.Rd
+++ b/man/ggrepel.Rd
@@ -50,7 +50,7 @@ Other contributors:
   \item Amir Masoud Abdol [contributor]
   \item Malcolm Barrett (\href{https://orcid.org/0000-0003-0299-5825}{ORCID}) [contributor]
   \item Robrecht Cannoodt (\href{https://orcid.org/0000-0003-3641-729X}{ORCID}) [contributor]
-  \item Michał Krassowski (\href{https://orcid.org/0000-0002-9638-7785}{ORCID}) [contributor]
+  \item Michal Krassowski (\href{https://orcid.org/0000-0002-9638-7785}{ORCID}) [contributor]
   \item Michael Chirico (\href{https://orcid.org/0000-0003-0787-087X}{ORCID}) [contributor]
   \item Pedro Aphalo (\href{https://orcid.org/0000-0003-3385-972X}{ORCID}) [contributor]
 }


### PR DESCRIPTION
In this version I simply modified the existing code that copies x and y to support "normal" position functions , to also copy x_orig and y_orig. I also edited the names of the values returned by position_nudge_repel() to be x_orig and x, and y_orig and y. This last edit makes it possible to use position_nudge_repel() with geom_text() and geom_label(), so it is optional.

This approach makes it unnecessary to edit the names elsewhere in the 'ggrepel' code. In the long run using the new names consistently in the whole package could be desirable for clarity but should not make a difference otherwise.