### PR TITLE
Support for {gridtext}

### DIFF
--- a/R/geom-text-repel.R
+++ b/R/geom-text-repel.R
@@ -90,6 +90,10 @@
 #' @param seed Random seed passed to \code{\link[base]{set.seed}}. Defaults to
 #'   \code{NA}, which means that \code{set.seed} will not be called.
 #' @param verbose If \code{TRUE}, some diagnostics of the repel algorithm are printed
+#' @param grob A grid grob generating function for displaying different types
+#'   of labels, for example \code{gridtext::richtext_grob()}.
+#' @param grob_args A list containing additional arguments to be passed to the
+#'   \code{grob} function that generates labels.
 #'
 #' @examples
 #'

--- a/man/geom_text_repel.Rd
+++ b/man/geom_text_repel.Rd
@@ -56,6 +56,8 @@ geom_text_repel(
   nudge_y = 0,
   xlim = c(NA, NA),
   ylim = c(NA, NA),
+  grob = textGrob,
+  grob_args = list(),
   na.rm = FALSE,
   show.legend = NA,
   direction = c("both", "y", "x"),
@@ -161,6 +163,12 @@ a warning.  If \code{TRUE} silently removes missing values.}
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
 the default plot specification, e.g. \code{\link[ggplot2]{borders}}.}
+
+\item{grob}{A grid grob generating function for displaying different types
+of labels, for example \code{gridtext::richtext_grob()}.}
+
+\item{grob_args}{A list containing additional arguments to be passed to the
+\code{grob} function that generates labels.}
 }
 \description{
 \code{geom_text_repel} adds text directly to the plot.

--- a/tests/testthat/_snaps/custom-grobs/geom-text-repel-circles.svg
+++ b/tests/testthat/_snaps/custom-grobs/geom-text-repel-circles.svg
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzIuNzl8NzE0LjUyfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='32.79' y='22.78' width='681.73' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzIuNzl8NzE0LjUyfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='32.79' y='22.78' width='681.73' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='231.11' cy='165.24' r='1.95' style='stroke-width: 0.71; stroke: #FF0000; fill: #FF0000;' />
+<circle cx='315.81' cy='256.25' r='1.95' style='stroke-width: 0.71; stroke: #FF0000; fill: #FF0000;' />
+<circle cx='285.86' cy='94.01' r='1.95' style='stroke-width: 0.71; stroke: #FF0000; fill: #FF0000;' />
+<circle cx='345.77' cy='311.65' r='1.95' style='stroke-width: 0.71; stroke: #FF0000; fill: #FF0000;' />
+<circle cx='512.58' cy='414.53' r='1.95' style='stroke-width: 0.71; stroke: #FF0000; fill: #FF0000;' />
+<circle cx='215.10' cy='145.45' r='1.95' style='stroke-width: 0.71; stroke: #FF0000; fill: #FF0000;' />
+<circle cx='357.65' cy='236.46' r='1.95' style='stroke-width: 0.71; stroke: #FF0000; fill: #FF0000;' />
+<circle cx='287.92' cy='371.00' r='1.95' style='stroke-width: 0.71; stroke: #FF0000; fill: #FF0000;' />
+<line x1='254.86' y1='168.78' x2='232.41' y2='165.43' style='stroke-width: 1.07;' />
+<line x1='291.94' y1='259.84' x2='314.52' y2='256.44' style='stroke-width: 1.07;' />
+<line x1='299.68' y1='84.09' x2='286.82' y2='93.32' style='stroke-width: 1.07;' />
+<line x1='369.58' y1='315.21' x2='347.07' y2='311.84' style='stroke-width: 1.07;' />
+<line x1='536.29' y1='411.02' x2='513.88' y2='414.34' style='stroke-width: 1.07;' />
+<line x1='191.44' y1='141.96' x2='213.81' y2='145.26' style='stroke-width: 1.07;' />
+<line x1='381.44' y1='232.91' x2='358.95' y2='236.27' style='stroke-width: 1.07;' />
+<line x1='264.17' y1='374.54' x2='286.63' y2='371.20' style='stroke-width: 1.07;' />
+<circle cx='275.08' cy='198.93' r='28.35' style='stroke-width: 1.50; stroke: #FFD700; fill: #FF0000;' />
+<circle cx='271.78' cy='289.99' r='28.35' style='stroke-width: 1.50; stroke: #FFD700; fill: #FF0000;' />
+<circle cx='329.82' cy='65.57' r='28.35' style='stroke-width: 1.50; stroke: #FFD700; fill: #FF0000;' />
+<circle cx='389.77' cy='345.35' r='28.35' style='stroke-width: 1.50; stroke: #FFD700; fill: #FF0000;' />
+<circle cx='556.52' cy='380.87' r='28.35' style='stroke-width: 1.50; stroke: #FFD700; fill: #FF0000;' />
+<circle cx='171.19' cy='111.81' r='28.35' style='stroke-width: 1.50; stroke: #FFD700; fill: #FF0000;' />
+<circle cx='401.64' cy='202.76' r='28.35' style='stroke-width: 1.50; stroke: #FFD700; fill: #FF0000;' />
+<circle cx='243.96' cy='404.68' r='28.35' style='stroke-width: 1.50; stroke: #FFD700; fill: #FF0000;' />
+<rect x='32.79' y='22.78' width='681.73' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='27.86' y='405.69' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='27.86' y='207.84' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<polyline points='30.05,402.66 32.79,402.66 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,204.81 32.79,204.81 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='167.07,547.85 167.07,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='373.66,547.85 373.66,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='580.24,547.85 580.24,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='167.07' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='373.66' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='580.24' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='373.66' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='11.00px' lengthAdjust='spacingAndGlyphs'>wt</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>mpg</text>
+<text x='32.79' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='143.10px' lengthAdjust='spacingAndGlyphs'>geom_text_repel_circles</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/custom-grobs/geom-text-repel-rectangles.svg
+++ b/tests/testthat/_snaps/custom-grobs/geom-text-repel-rectangles.svg
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzIuNzl8NzE0LjUyfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='32.79' y='22.78' width='681.73' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzIuNzl8NzE0LjUyfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='32.79' y='22.78' width='681.73' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='231.11' cy='165.24' r='1.95' style='stroke-width: 0.71; stroke: #FF0000; fill: #FF0000;' />
+<circle cx='315.81' cy='256.25' r='1.95' style='stroke-width: 0.71; stroke: #FF0000; fill: #FF0000;' />
+<circle cx='285.86' cy='94.01' r='1.95' style='stroke-width: 0.71; stroke: #FF0000; fill: #FF0000;' />
+<circle cx='345.77' cy='311.65' r='1.95' style='stroke-width: 0.71; stroke: #FF0000; fill: #FF0000;' />
+<circle cx='512.58' cy='414.53' r='1.95' style='stroke-width: 0.71; stroke: #FF0000; fill: #FF0000;' />
+<circle cx='215.10' cy='145.45' r='1.95' style='stroke-width: 0.71; stroke: #FF0000; fill: #FF0000;' />
+<circle cx='357.65' cy='236.46' r='1.95' style='stroke-width: 0.71; stroke: #FF0000; fill: #FF0000;' />
+<circle cx='287.92' cy='371.00' r='1.95' style='stroke-width: 0.71; stroke: #FF0000; fill: #FF0000;' />
+<line x1='245.07' y1='174.92' x2='232.09' y2='165.92' style='stroke-width: 1.07;' />
+<line x1='301.91' y1='265.91' x2='314.83' y2='256.93' style='stroke-width: 1.07;' />
+<line x1='299.73' y1='84.37' x2='286.84' y2='93.33' style='stroke-width: 1.07;' />
+<line x1='359.61' y1='321.27' x2='346.75' y2='312.33' style='stroke-width: 1.07;' />
+<line x1='526.48' y1='404.88' x2='513.56' y2='413.85' style='stroke-width: 1.07;' />
+<line x1='201.19' y1='135.79' x2='214.12' y2='144.77' style='stroke-width: 1.07;' />
+<line x1='371.48' y1='226.85' x2='358.63' y2='235.78' style='stroke-width: 1.07;' />
+<line x1='274.07' y1='380.63' x2='286.94' y2='371.68' style='stroke-width: 1.07;' />
+<rect x='246.87' y='159.81' width='28.35' height='56.69' style='stroke-width: 0.75; fill: #FFD700;' />
+<rect x='271.76' y='250.78' width='28.35' height='56.69' style='stroke-width: 0.75; fill: #FFD700;' />
+<rect x='301.53' y='42.80' width='28.35' height='56.69' style='stroke-width: 0.75; fill: #FFD700;' />
+<rect x='361.41' y='306.15' width='28.35' height='56.69' style='stroke-width: 0.75; fill: #FFD700;' />
+<rect x='528.28' y='363.31' width='28.35' height='56.69' style='stroke-width: 0.75; fill: #FFD700;' />
+<rect x='171.05' y='94.20' width='28.35' height='56.69' style='stroke-width: 0.75; fill: #FFD700;' />
+<rect x='373.28' y='185.28' width='28.35' height='56.69' style='stroke-width: 0.75; fill: #FFD700;' />
+<rect x='243.93' y='365.52' width='28.35' height='56.69' style='stroke-width: 0.75; fill: #FFD700;' />
+<rect x='32.79' y='22.78' width='681.73' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='27.86' y='405.69' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='27.86' y='207.84' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<polyline points='30.05,402.66 32.79,402.66 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,204.81 32.79,204.81 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='167.07,547.85 167.07,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='373.66,547.85 373.66,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='580.24,547.85 580.24,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='167.07' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='373.66' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='580.24' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='373.66' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='11.00px' lengthAdjust='spacingAndGlyphs'>wt</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>mpg</text>
+<text x='32.79' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='166.60px' lengthAdjust='spacingAndGlyphs'>geom_text_repel_rectangles</text>
+</g>
+</svg>

--- a/tests/testthat/test-custom-grobs.R
+++ b/tests/testthat/test-custom-grobs.R
@@ -1,0 +1,46 @@
+test_that("geom_text_repel() works with custom grobs", {
+
+  my.cars <- mtcars[c(TRUE, FALSE, FALSE, FALSE), ]
+  my.cars$car.names <- rownames(my.cars)
+
+  p <- ggplot(my.cars, aes(wt, mpg, label = car.names)) +
+    geom_point(colour = "red") +
+    expand_limits(x = c(1, 7), y = c(12, 24))
+
+  custom_rectangles <- function(label, x, y, hjust, vjust, ..., fill) {
+    grid::rectGrob(
+      x = x, y = y, width = unit(1, "cm"), height = unit(2, "cm"),
+      hjust = hjust, vjust = vjust, gp = gpar(fill = fill, col = "black")
+    )
+  }
+
+  p + geom_text_repel(
+    min.segment.length = 0, box.padding = 1,
+    grob = custom_rectangles, grob_args = list(fill = "gold")
+  )
+
+  vdiffr::expect_doppelganger(
+    "geom_text_repel_rectangles",
+    p + geom_text_repel(
+      min.segment.length = 0, box.padding = 1,
+      grob = custom_rectangles, grob_args = list(fill = "gold"),
+      seed = 1234
+    )
+  )
+
+  custom_circles <- function(label, x, y, ..., custom_gp) {
+    grid::circleGrob(x = x, y = y, r = unit(1, "cm"), gp = custom_gp)
+  }
+
+  vdiffr::expect_doppelganger(
+    "geom_text_repel_circles",
+    p + geom_text_repel(
+      min.segment.length = 0, box.padding = 1,
+      grob = custom_circles,
+      grob_args = list(
+        custom_gp = gpar(fill = "red", col = "gold", linetype = 2, lwd = 2)
+      ),
+      seed = 1234
+    )
+  )
+})


### PR DESCRIPTION
This PR aims to fix #169.

Briefly, this PR gives `geom_text_repel()` a `grob` argument that can be used to provide a different grob constructor than `textGrob()`. You can pass, for example, a `gridtext::richtext_grob()` to draw the labels.

``` r
devtools::load_all("~/packages/gridtext/") # explained later why I'm using devtools here
#> ℹ Loading gridtext
devtools::load_all("~/packages/ggrepel")
#> ℹ Loading ggrepel
#> Loading required package: ggplot2

logo <- system.file("extdata", "Rlogo.png", package = "gridtext")

df <- data.frame(
  x = c(0, 4.9,5,5.1, 10),
  y = c(0, 4.9,5,5.1, 10),
  labels = c(
    "Some <span style='color:blue'>*italic blue*</span> text",
    "Other <span style='color:red'>**bold red**</span> text",
    paste0("<img src='", logo, "' width = '50'/>"),
    "Text with some <sup>superscript</sup>",
    "Drink enough H<sub>2</sub>O."
  )
)

ggplot(df, aes(x, y)) +
  geom_point() +
  geom_text_repel(
    aes(label = labels), 
    grob = richtext_grob
  )
```

![](https://i.imgur.com/y1taOYr.png)<!-- -->

To control additional arguments to that grob constructor, that don't have the plumbing to go through the parameters or aesthetics, you pass a list to `grob_args`.

``` r
ggplot(df, aes(x, y)) +
  geom_point() +
  geom_text_repel(
    aes(label = labels), 
    grob = richtext_grob,
    grob_args = list(
      padding = margin(10, 10, 10, 10),
      box_gp = gpar(fill = "#88888844", col = "grey"),
      r = unit(10, "pt")
    )
  )
```

![](https://i.imgur.com/08fpu3U.png)<!-- -->

<sup>Created on 2024-01-13 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

To get this to work I had to make the following changes:

1. Install the plumbing for `grob` and `grob_args` to reach the place where they're used and avoid argument clashes and mismatches.
2. I had to change how the sizes of labels are measured. For rich text grobs, the labels can have a lot of additional html/markdown markup that count towards `stringWidth()` or `stringHeight()` of the label, but are not part of the actual size of the label. Now, the grobs themselves are measured instead of just their labels.

I've marked this PR as a draft because there is a caveat. You cannot use any grob constructor as the `grob` argument. Well, you probably can but that'd return errors or draw the labels incorrectly. The grob *must* have a decent `xDetails()` or `yDetails()` method to be accurately measured. Currently, {gridtext} does not have these methods, but I've offered to implement these in https://github.com/wilkelab/gridtext/issues/33. That is why I'm using my local copy of {gridtext} in the example, because that points to a local repo with those changes implemented. It'd probably make sense to only merge this PR if {gridtext} accepts the other PR.

