### PR TITLE
Add show_warning argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,6 +53,6 @@ VignetteBuilder: knitr
 License: GPL-3 | file LICENSE
 URL: https://ggrepel.slowkow.com/, https://github.com/slowkow/ggrepel
 BugReports: https://github.com/slowkow/ggrepel/issues
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 LinkingTo: Rcpp
 Encoding: UTF-8

--- a/R/geom-label-repel.R
+++ b/R/geom-label-repel.R
@@ -32,6 +32,7 @@ geom_label_repel <- function(
   direction = c("both","y","x"),
   seed = NA,
   verbose = FALSE,
+  show_warning = TRUE,
   inherit.aes = TRUE
 ) {
   if (!missing(nudge_x) || !missing(nudge_y)) {
@@ -300,7 +301,7 @@ makeContent.labelrepeltree <- function(x) {
     verbose         = x$verbose
   ))
 
-  if (any(repel$too_many_overlaps)) {
+  if (any(repel$too_many_overlaps) & show_warning) {
     warn(
       sprintf(
         "ggrepel: %s unlabeled data points (too many overlaps). Consider increasing max.overlaps",

--- a/R/geom-text-repel.R
+++ b/R/geom-text-repel.R
@@ -90,6 +90,7 @@
 #' @param seed Random seed passed to \code{\link[base]{set.seed}}. Defaults to
 #'   \code{NA}, which means that \code{set.seed} will not be called.
 #' @param verbose If \code{TRUE}, some diagnostics of the repel algorithm are printed
+#' @param show_warning If \code{TRUE} (default), warnings are shown.
 #'
 #' @examples
 #'
@@ -182,6 +183,7 @@ geom_text_repel <- function(
   direction = c("both","y","x"),
   seed = NA,
   verbose = FALSE,
+  show_warning = TRUE,
   inherit.aes = TRUE
 ) {
   if (!missing(nudge_x) || !missing(nudge_y)) {
@@ -313,7 +315,7 @@ GeomTextRepel <- ggproto("GeomTextRepel", Geom,
     limits$y[is.na(limits$y)] <- c(0, 1)[is.na(limits$y)]
 
     # Warn about limitations of the algorithm
-    if (any(abs(data$angle %% 90) > 5)) {
+    if (any(abs(data$angle %% 90) > 5) & show_warning) {
       warn("ggrepel: Repulsion works correctly only for rotation angles multiple of 90 degrees")
     }
 
@@ -441,7 +443,7 @@ makeContent.textrepeltree <- function(x) {
     verbose         = x$verbose
   ))
 
-  if (any(repel$too_many_overlaps)) {
+  if (any(repel$too_many_overlaps) & show_warning) {
     warn(
       sprintf(
         "ggrepel: %s unlabeled data points (too many overlaps). Consider increasing max.overlaps",

--- a/man/geom_text_repel.Rd
+++ b/man/geom_text_repel.Rd
@@ -33,6 +33,7 @@ geom_label_repel(
   direction = c("both", "y", "x"),
   seed = NA,
   verbose = FALSE,
+  show_warning = TRUE,
   inherit.aes = TRUE
 )
 
@@ -61,6 +62,7 @@ geom_text_repel(
   direction = c("both", "y", "x"),
   seed = NA,
   verbose = FALSE,
+  show_warning = TRUE,
   inherit.aes = TRUE
 )
 }
@@ -156,6 +158,8 @@ a warning.  If \code{TRUE} silently removes missing values.}
 \code{NA}, which means that \code{set.seed} will not be called.}
 
 \item{verbose}{If \code{TRUE}, some diagnostics of the repel algorithm are printed}
+
+\item{show_warning}{If \code{TRUE} (default), warnings are shown.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions


### PR DESCRIPTION
This addresses issue #187. 

I have the same problem with warnings from `ggrepel` showing up in unexpected places. I don't manage to suppress them either with `SuppressWarnings()`. Therefore, I added an additional argument to `geom_text_repel()` and `geom_label_repel()` called `show_warning` that allows the user to disable the display of warnings. The default is `TRUE` so that there is no change from the current behaviour. 
