### PR TITLE
improve point size calculations

### DIFF
--- a/R/geom-label-repel.R
+++ b/R/geom-label-repel.R
@@ -321,6 +321,11 @@ makeContent.labelrepeltree <- function(x) {
     return(setChildren(x, grobs))
   }
 
+  width  <- convertWidth(unit(1, "npc"), "cm", valueOnly = TRUE)
+  height <- convertHeight(unit(1, "npc"), "cm", valueOnly = TRUE)
+  point_size <- x$data$point.size * .pt / .stroke / 20
+  point_padding <- convertWidth(to_unit(x$point.padding), "cm", TRUE)
+
   grobs <- lapply(seq_along(valid_strings), function(i) {
     if (!repel$too_many_overlaps[i]) {
       row <- x$data[i, , drop = FALSE]
@@ -339,7 +344,7 @@ makeContent.labelrepeltree <- function(x) {
         box.padding = x$box.padding,
         label.padding = x$label.padding,
         point.size = point_size[i],
-        point.padding = x$point.padding,
+        point.padding = point_padding,
         segment.curvature = row$segment.curvature,
         segment.angle     = row$segment.angle,
         segment.ncp       = row$segment.ncp,
@@ -369,7 +374,8 @@ makeContent.labelrepeltree <- function(x) {
         arrow = x$arrow,
         min.segment.length = x$min.segment.length,
         hjust = row$hjust,
-        vjust = row$vjust
+        vjust = row$vjust,
+        dim = c(width, height)
       )
     }
   })
@@ -419,7 +425,8 @@ makeLabelRepelGrobs <- function(
   arrow = NULL,
   min.segment.length = 0.5,
   hjust = 0.5,
-  vjust = 0.5
+  vjust = 0.5,
+  dim = c(5, 5)
 ) {
   stopifnot(length(label) == 1)
 
@@ -474,10 +481,10 @@ makeLabelRepelGrobs <- function(
     point_inside_text <- TRUE
   }
 
-  # This seems just fine.
-  point.padding <- convertWidth(to_unit(point.padding), "native", TRUE) / 2
-
-  point_int <- intersect_line_circle(int, point_pos, (point.size + point.padding))
+  # We multiply with `dim` here to compute this in centimetres, in which
+  # the point size/padding are given.
+  point_int <- intersect_line_circle(int * dim, point_pos * dim, (point.size + point.padding))
+  point_int <- point_int / dim
 
   # Compute the distance between the data point and the edge of the text box.
   dx <- abs(int[1] - point_pos[1])
@@ -501,7 +508,7 @@ makeLabelRepelGrobs <- function(
     # Distance from label to point edge is less than from label to point center.
     euclid(int, point_int) < euclid(int, point_pos) &&
     # Distance from label to point center is greater than point size.
-    euclid(int, point_pos) > point.size &&
+    euclid(int * dim, point_pos * dim) > point.size &&
     # Distance from label to point center is greater than from point edge to point center.
     euclid(int, point_pos) > euclid(point_int, point_pos)
   ) {


### PR DESCRIPTION
This PR aims  to fix #83 and replaces #251.

Briefly, it is a more surgical approach than #251 where we only execute calculations involving the point size in centimetres and keep the rest as-is.

Reprex from the issue:

``` r
devtools::load_all("~/packages/ggrepel")
#> ℹ Loading ggrepel
#> Loading required package: ggplot2

set.seed(42)
d <- data.frame(
  x = c(1, 2, 2, 3),
  y = c(1, 2, 3, 1),
  pointsize = c(0, 2, 1, 0),
  label = sprintf("label%s", 1:4)
)

ggplot(d, aes(x, y)) +
  geom_point(aes(size = pointsize), color = "grey50") +
  geom_text_repel(
    min.segment.length = 0.1,
    box.padding = 0.2,
    aes(label = label, point.size = pointsize),
    size = 5, max.iter = 1e5, max.time = 1
  ) +
  continuous_scale(
    aesthetics = c("size", "point.size"), 
    palette = scales::area_pal(c(2, 50)), guide = "none"
  )
```

![](https://i.imgur.com/cs9RkKm.png)<!-- -->

Example of #251's Achilles' heel:

``` r
set.seed(42)
ggplot(mtcars, aes(x = wt, y = 1, label = rownames(mtcars))) +
  geom_point(color = "red") +
  geom_text_repel(
    force_pull   = 0, # do not pull toward data points
    nudge_y      = 0.05,
    direction    = "x",
    angle        = 90,
    hjust        = 0,
    segment.size = 0.2,
    max.iter = 1e4, max.time = 1,
    point.size = 1.5
  ) +
  xlim(1, 6) +
  ylim(1, 0.8) +
  theme(
    axis.line.y  = element_blank(),
    axis.ticks.y = element_blank(),
    axis.text.y  = element_blank(),
    axis.title.y = element_blank()
  )
```

![](https://i.imgur.com/0zsd57z.png)<!-- -->

<sup>Created on 2024-12-02 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
